### PR TITLE
Add generic CRUD repository implementation with UUID support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/repository/crud_repository.go
+++ b/repository/crud_repository.go
@@ -1,0 +1,105 @@
+package repository
+
+import (
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type CrudRepository[T any] interface {
+	Create(et T) (*T, error)
+	FindByID(id uuid.UUID) (*T, error)
+	Update(et T) (*T, error)
+	Delete(id uuid.UUID) error
+	ListAll() ([]T, error)
+	First(et T) (*T, error)
+	FindWithEntity(et T) ([]T, error)
+	FindWithConditions(conditions map[string]any) ([]T, error)
+	FindWithOrConditions(conditions map[string]any) ([]T, error)
+	CountWithConditions(conditions map[string]any) (int64, error)
+	CountWithEntity(et T) (int64, error)
+}
+
+func NewCrudRepository[T any](db *gorm.DB) CrudRepository[T] {
+	return &crudRepository[T]{db: db}
+}
+
+type crudRepository[T any] struct {
+	db *gorm.DB
+}
+
+func (r *crudRepository[T]) Create(et T) (*T, error) {
+	v := validator.New()
+	if err := v.Struct(et); err != nil {
+		return nil, err
+	}
+	err := r.db.Create(&et).Error
+	return &et, err
+}
+
+func (r *crudRepository[T]) FindByID(id uuid.UUID) (*T, error) {
+	var et T
+	err := r.db.First(&et, id).Error
+	return &et, err
+}
+
+func (r *crudRepository[T]) Update(et T) (*T, error) {
+	v := validator.New()
+	if err := v.Struct(et); err != nil {
+		return nil, err
+	}
+	err := r.db.Save(&et).Error
+	return &et, err
+}
+
+func (r *crudRepository[T]) Delete(id uuid.UUID) error {
+	var et T
+	return r.db.Delete(&et, id).Error
+}
+
+func (r *crudRepository[T]) ListAll() ([]T, error) {
+	var entities []T
+	err := r.db.Find(&entities).Error
+	return entities, err
+}
+
+func (r *crudRepository[T]) First(et T) (*T, error) {
+	var existed T
+	err := r.db.Where(et).First(&existed).Error
+	return &existed, err
+}
+
+func (r *crudRepository[T]) FindWithEntity(et T) ([]T, error) {
+	var entities []T
+	err := r.db.Where(et).Find(&entities).Error
+	return entities, err
+}
+
+func (r *crudRepository[T]) FindWithConditions(conditions map[string]any) ([]T, error) {
+	var entities []T
+	err := r.db.Where(conditions).Find(&entities).Error
+	return entities, err
+}
+func (r *crudRepository[T]) FindWithOrConditions(conditions map[string]any) ([]T, error) {
+	var entities []T
+	query := r.db.Model(new(T))
+	for key, value := range conditions {
+		query.Or(fmt.Sprintf("%s = ?", key), value)
+	}
+	err := query.Find(&entities).Error
+	return entities, err
+}
+
+func (r *crudRepository[T]) CountWithConditions(conditions map[string]any) (int64, error) {
+	var count int64
+	err := r.db.Model(new(T)).Where(conditions).Count(&count).Error
+	return count, err
+}
+
+func (r *crudRepository[T]) CountWithEntity(et T) (int64, error) {
+	var count int64
+	err := r.db.Model(new(T)).Where(et).Count(&count).Error
+	return count, err
+}


### PR DESCRIPTION
Introduce a generic CRUD repository interface and its implementation, enabling operations with UUIDs for entity management. This implementation includes methods for creating, finding, updating, deleting, and listing entities.