### PR TITLE
Refactor ListPaged method to return total count

### DIFF
--- a/repository/mocks/mock_crud_repository.go
+++ b/repository/mocks/mock_crud_repository.go
@@ -73,7 +73,7 @@ func (m *MockCrudRepository[T]) Exists(ctx context.Context, conditions map[strin
 }
 
 // Add mock for new paging method
-func (m *MockCrudRepository[T]) ListPaged(ctx context.Context, offset int, limit int) ([]T, error) {
+func (m *MockCrudRepository[T]) ListPaged(ctx context.Context, offset int, limit int) ([]T, int64, error) {
 	args := m.Called(ctx, offset, limit)
-	return args.Get(0).([]T), args.Error(1)
+	return args.Get(0).([]T), args.Get(1).(int64), args.Error(2)
 }


### PR DESCRIPTION
Update the ListPaged method to return both the entities and the total count of entities, improving efficiency by executing the count and paging queries concurrently.