### PR TITLE
Add Patch method to CrudRepository for partial updates

### DIFF
--- a/repository/crud_repository.go
+++ b/repository/crud_repository.go
@@ -16,6 +16,7 @@ type CrudRepository[T any] interface {
 	Create(ctx context.Context, et *T) (*T, error)
 	FindByID(ctx context.Context, id uuid.UUID) (*T, error)
 	Update(ctx context.Context, et *T) (*T, error)
+	Patch(ctx context.Context, et *T) (*T, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	ListAll(ctx context.Context) ([]T, error)
 	First(ctx context.Context, et *T) (*T, error)
@@ -62,6 +63,22 @@ func (r *crudRepository[T]) Update(ctx context.Context, et *T) (*T, error) {
 		return nil, err
 	}
 	err := r.db.WithContext(ctx).Save(et).Error
+	return et, err
+}
+
+func (r *crudRepository[T]) Patch(ctx context.Context, et *T) (*T, error) {
+	var updated T
+	err := r.db.WithContext(ctx).Model(et).Updates(et).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// Reload the updated entity from the DB.
+	err = r.db.WithContext(ctx).Model(et).First(&updated).Error
+	if err != nil {
+		return nil, err
+	}
+
 	return et, err
 }
 

--- a/repository/mocks/mock_crud_repository.go
+++ b/repository/mocks/mock_crud_repository.go
@@ -77,3 +77,8 @@ func (m *MockCrudRepository[T]) ListPaged(ctx context.Context, offset int, limit
 	args := m.Called(ctx, offset, limit)
 	return args.Get(0).([]T), args.Get(1).(int64), args.Error(2)
 }
+
+func (m *MockCrudRepository[T]) Patch(ctx context.Context, entity *T) (*T, error) {
+	args := m.Called(ctx, entity)
+	return args.Get(0).(*T), args.Error(1)
+}


### PR DESCRIPTION
Introduce a Patch method to enable partial updates of entities in the CrudRepository interface, enhancing flexibility in entity management. Update the mock repository to support this new method.